### PR TITLE
update to setuptools and enable msvc compilation by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ Now you can install the package with
 pip install .
 ```
 
-4.
-
 ## Run test with example
 
 After installation, it would possible to run the test example `visilibity_test.py`.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,24 @@ To install the Python package:
 
 `pip install visilibity`
 
+### On Windows
+
+Make sure you have the buildtools installed:
+1. Download [Buildtools für Visual Studio 2022](https://aka.ms/vs/17/release/vs_BuildTools.exe)
+2. Select `C++ Tools for Linux Development` and install
+
+After that you need to install the `swig` and `cython`. When using conda just run 
+```
+conda install swig boost cython
+```
+
+Now you can install the package with
+```
+pip install .
+```
+
+4.
+
 ## Run test with example
 
 After installation, it would possible to run the test example `visilibity_test.py`.

--- a/setup.py
+++ b/setup.py
@@ -21,15 +21,16 @@ from setuptools.command.build import build
 
 class CustomBuild(build):
     sub_commands = [
-        ('build_ext',     build.has_ext_modules),
-        ('build_py',      build.has_pure_modules),
-        ('build_clib',    build.has_c_libraries),
-        ('build_scripts', build.has_scripts),
-                    ]
+        ('build_ext', lambda self: True),
+        ('build_py', lambda self: True),
+        ('build_clib', lambda self: True),
+        ('build_scripts', lambda self: True),
+    ]
+    
+module = Extension('_visilibity', swig_opts=['-c++'],
+                   sources=['visilibity.i', 'visilibity.cpp'],
+                   include_dirs=['.'])  # Assuming 'visilibity.hpp' is in the current directory
 
-module = Extension('_visilibity', swig_opts = ['-c++'],
-        sources = ['visilibity.i', 'visilibity.cpp'],
-        headers = ['visilibity.hpp'], include = ['visilibity.hpp'])
 
 setup (name = 'VisiLibity',
        version = '1.0.10',

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from distutils.core import setup, Extension
-from distutils.command.build import build
+from setuptools import setup, Extension
+from setuptools.command.build import build
+
 
 class CustomBuild(build):
     sub_commands = [

--- a/visilibity.hpp
+++ b/visilibity.hpp
@@ -49,8 +49,6 @@ License along with VisiLibity.  If not, see <http://www.gnu.org/licenses/>.
 //Microsoft Visual Studio
 
 #include <limits>
-#define NAN std::numeric_limits<double>::quiet_NaN()
-#define INFINITY std::numeric_limits<double>::infinity()
 #define M_PI 3.141592653589793238462643
 #define and &&
 #define or ||

--- a/visilibity.hpp
+++ b/visilibity.hpp
@@ -47,14 +47,14 @@ License along with VisiLibity.  If not, see <http://www.gnu.org/licenses/>.
 
 //Uncomment these lines when compiling under
 //Microsoft Visual Studio
-/*
+
 #include <limits>
 #define NAN std::numeric_limits<double>::quiet_NaN()
 #define INFINITY std::numeric_limits<double>::infinity()
 #define M_PI 3.141592653589793238462643
 #define and &&
 #define or ||
-*/
+// uncomment end
 
 #include <cmath>      //math functions in std namespace
 #include <vector>


### PR DESCRIPTION
I changed distutils to setuptools (distutils is deprecated) and enabled the installation under windows (by uncommenting some of the msvc comments). 
In my test this version also installs without issues under linux, so i propose to leave the lines uncommented by default.
Also added some instructions for the installation on windows.